### PR TITLE
Updated IE, EI, EZ and ZE counter examples

### DIFF
--- a/data_extraction/classes/ei_extractor.py
+++ b/data_extraction/classes/ei_extractor.py
@@ -52,26 +52,32 @@ class EIExtractor:
 
             # Check if there are enough characters and the intron ends with 'ag'
             if intron_end - 1 >= 0 and sequence[intron_end - 1:intron_end + 1] == "ag":
-                left = sequence[max(0, intron_end - 100):intron_end]
-                right = sequence[intron_end:intron_end + 5]
-                transition_seq = left + right  # 100 + 5 = 105 characters
-                reduced_transition_seq = transition_seq[-12:] # 12 characters
+                left = sequence[max(0, intron_end - 6):intron_end]
+                right = sequence[intron_end:intron_end + 6]
+                reduced_transition_seq = left + right # 12 characters
+                reduced_transition_seq = list(reduced_transition_seq)
+                reduced_transition_seq[5:7] = ["g", "t"]
+                reduced_transition_seq = "".join(reduced_transition_seq)
                 self.ie_counter_example_data.append([gen_id, chromosome, global_start, None, *list(reduced_transition_seq)])
 
     def extract_ez_counter_example(self, gen_id, chromosome, global_start, sequence, exons):
         exon_end = exons[-1][1]
-        left = sequence[max(0, exon_end - 50):exon_end]
-        right = sequence[exon_end:exon_end + 500]
-        transition_seq = left + right # 500 + 50 = 550 characters
-        reduced_transition_seq = transition_seq[-12:]
+        left = sequence[max(0, exon_end - 6):exon_end]
+        right = sequence[exon_end:exon_end + 6]
+        reduced_transition_seq = left + right # 12 characters
+        reduced_transition_seq = list(reduced_transition_seq)
+        reduced_transition_seq[5:7] = ["g", "t"]
+        reduced_transition_seq = "".join(reduced_transition_seq)
         self.ez_counter_example_data.append([gen_id, chromosome, global_start, None, *list(reduced_transition_seq)])
 
     def extract_ze_counter_example(self, gen_id, chromosome, global_start, sequence, exons):
         exon_start = exons[0][0]
-        left = sequence[max(0, exon_start - 500):exon_start]
-        right = sequence[exon_start:exon_start + 50]
-        transition_seq = left + right # 500 + 50 = 550 characters
-        reduced_transition_seq = transition_seq[-12:] # 12 characters
+        left = sequence[max(0, exon_start - 6):exon_start]
+        right = sequence[exon_start:exon_start + 6]
+        reduced_transition_seq = left + right # 12 characters
+        reduced_transition_seq = list(reduced_transition_seq)
+        reduced_transition_seq[5:7] = ["g", "t"]
+        reduced_transition_seq = "".join(reduced_transition_seq)
         self.ze_counter_example_data.append([gen_id, chromosome, global_start, None, *list(reduced_transition_seq)])
 
     def get_data(self):

--- a/data_extraction/classes/ez_extractor.py
+++ b/data_extraction/classes/ez_extractor.py
@@ -40,10 +40,9 @@ class EZExtractor:
             # Check if there are enough characters and the intron starts with 'gt'
             if intron_start + 1 < len(sequence) and sequence[intron_start:intron_start + 2] == "gt":
                 # Extract 5 nucleotides to the left and 7 to the right
-                left = sequence[max(0, intron_start - 5):intron_start]
-                right = sequence[intron_start:intron_start + 7]
-                transition_seq = left + right  # 12 characters
-                expanded_transition_seq = (transition_seq * 46)[:550]  # 550 characters
+                left = sequence[max(0, intron_start - 50):intron_start]
+                right = sequence[intron_start:intron_start + 500]
+                expanded_transition_seq = left + right # 500 + 50 = 550 characters
                 self.ei_counter_example_data.append(
                     [gen_id, chromosome, global_start, exon_end, *list(expanded_transition_seq)])
 
@@ -54,17 +53,16 @@ class EZExtractor:
 
             # Check if there are enough characters and the intron ends with 'ag'
             if intron_end - 1 >= 0 and sequence[intron_end - 1:intron_end + 1] == "ag":
-                left = sequence[max(0, intron_end - 100):intron_end]
-                right = sequence[intron_end:intron_end + 5]
-                transition_seq = left + right  # 100 + 5 = 105 characters
-                expanded_transition_seq = (transition_seq * 6)[:550] # 550 characters
+                left = sequence[max(0, intron_end - 50):intron_end]
+                right = sequence[intron_end:intron_end + 500]
+                expanded_transition_seq = left + right # 500 + 50 = 550 characters
                 self.ie_counter_example_data.append(
                     [gen_id, chromosome, global_start, None, *list(expanded_transition_seq)])
 
     def extract_ze_counter_example(self, gen_id, chromosome, global_start, sequence, exons):
         exon_start = exons[0][0]
-        left = sequence[max(0, exon_start - 500):exon_start]
-        right = sequence[exon_start:exon_start + 50]
+        left = sequence[max(0, exon_start - 50):exon_start]
+        right = sequence[exon_start:exon_start + 500]
         transition_seq = left + right  # 500 + 50 = 550 characters
         self.ze_counter_example_data.append([gen_id, chromosome, global_start, None, *list(transition_seq)])
 

--- a/data_extraction/classes/ie_extractor.py
+++ b/data_extraction/classes/ie_extractor.py
@@ -46,27 +46,35 @@ class IEExtractor:
 
             # Check if there are enough characters and the intron starts with 'gt'
             if intron_start + 1 < len(sequence) and sequence[intron_start:intron_start + 2] == "gt":
-                # Extract 5 nucleotides to the left and 7 to the right
-                left = sequence[max(0, intron_start - 5):intron_start]
-                right = sequence[intron_start:intron_start + 7]
-                transition_seq = left + right # 12 characters
-                expanded_transition_seq = (transition_seq * 9)[:105] # 105 characters
+                left = sequence[max(0, intron_start - 100):intron_start]
+                right = sequence[intron_start:intron_start + 5]
+                expanded_transition_seq = left + right #  100 + 5 = 105 characters
+                # Insert ag to simulate the end of the intron
+                expanded_transition_seq = list(expanded_transition_seq)
+                expanded_transition_seq[99:101] = ["a", "g"]
+                expanded_transition_seq = "".join(expanded_transition_seq)
                 self.ei_counter_example_data.append([gen_id, chromosome, global_start, exon_end, *list(expanded_transition_seq)])
 
     def extract_ez_counter_example(self, gen_id, chromosome, global_start, sequence, exons):
         exon_end = exons[-1][1]
-        left = sequence[max(0, exon_end - 50):exon_end]
-        right = sequence[exon_end:exon_end + 500]
-        transition_seq = left + right # 500 + 50 = 550 characters
-        reduced_transition_seq = transition_seq[-105:] # 105 characters
+        left = sequence[max(0, exon_end - 100):exon_end]
+        right = sequence[exon_end:exon_end + 5]
+        reduced_transition_seq = left + right # 100 + 5 = 105 characters
+        # Insert ag to simulate the end of the intron
+        reduced_transition_seq = list(reduced_transition_seq)
+        reduced_transition_seq[99:101] = ["a", "g"]
+        reduced_transition_seq = "".join(reduced_transition_seq)
         self.ez_counter_example_data.append([gen_id, chromosome, global_start, None, *list(reduced_transition_seq)])
 
     def extract_ze_counter_example(self, gen_id, chromosome, global_start, sequence, exons):
         exon_start = exons[0][0]
-        left = sequence[max(0, exon_start - 500):exon_start]
-        right = sequence[exon_start:exon_start + 50]
-        transition_seq = left + right # 500 + 50 = 550 characters
-        reduced_transition_seq = transition_seq[-105:] # 105 characters
+        left = sequence[max(0, exon_start - 100):exon_start]
+        right = sequence[exon_start:exon_start + 5]
+        reduced_transition_seq = left + right # 100 + 5 = 105 characters
+        # Insert ag to simulate the end of the intron
+        reduced_transition_seq = list(reduced_transition_seq)
+        reduced_transition_seq[99:101] = ["a", "g"]
+        reduced_transition_seq = "".join(reduced_transition_seq)
         self.ze_counter_example_data.append([gen_id, chromosome, global_start, None, *list(reduced_transition_seq)])
 
     def get_data(self):

--- a/data_extraction/classes/ze_extractor.py
+++ b/data_extraction/classes/ze_extractor.py
@@ -40,10 +40,9 @@ class ZEExtractor:
             # Check if there are enough characters and the intron starts with 'gt'
             if intron_start + 1 < len(sequence) and sequence[intron_start:intron_start + 2] == "gt":
                 # Extract 5 nucleotides to the left and 7 to the right
-                left = sequence[max(0, intron_start - 5):intron_start]
-                right = sequence[intron_start:intron_start + 7]
-                transition_seq = left + right # 12 characters
-                expanded_transition_seq = (transition_seq * 46)[:550]
+                left = sequence[max(0, intron_start - 500):intron_start]
+                right = sequence[intron_start:intron_start + 50]
+                expanded_transition_seq = left + right # 500 + 50 = 550 characters
                 self.ei_counter_example_data.append([gen_id, chromosome, global_start, exon_end, *list(expanded_transition_seq)])
 
     def extract_ie_counter_example(self, gen_id, chromosome, global_start, sequence, exons):
@@ -53,16 +52,15 @@ class ZEExtractor:
 
             # Check if there are enough characters and the intron ends with 'ag'
             if intron_end - 1 >= 0 and sequence[intron_end - 1:intron_end + 1] == "ag":
-                left = sequence[max(0, intron_end - 100):intron_end]
-                right = sequence[intron_end:intron_end + 5]
-                transition_seq = left + right  # 100 + 5 = 105 characters
-                expanded_transition_seq = (transition_seq * 6)[:550] # 550 characters
+                left = sequence[max(0, intron_end - 500):intron_end]
+                right = sequence[intron_end:intron_end + 50]
+                expanded_transition_seq = left + right  # 500 + 50 = 550 characters
                 self.ie_counter_example_data.append([gen_id, chromosome, global_start, None, *list(expanded_transition_seq)])
 
     def extract_ez_counter_example(self, gen_id, chromosome, global_start, sequence, exons):
         exon_end = exons[-1][1]
-        left = sequence[max(0, exon_end - 50):exon_end]
-        right = sequence[exon_end:exon_end + 500]
+        left = sequence[max(0, exon_end - 500):exon_end]
+        right = sequence[exon_end:exon_end + 50]
         transition_seq = left + right # 500 + 50 = 550 characters
         self.ez_counter_example_data.append([gen_id, chromosome, global_start, None, *list(transition_seq)])
 


### PR DESCRIPTION
Now all interest points are in the right position, to do a better simulation

**Example** 

If we are in IE, doing an EI counter example:

In IE we have 105 characters, with AG in position [99,100] (considering list starts in 0), and EI has 12 characters with interest point in [5:6] with GT.

So the counter example will have the interest point in the same position as real data, adding some characters to have the same large.

That means that in position [99,100] will be GT (interest point of EI). But replaced to be a counter example, which is translated in having AG in [99:100]

What we do is take the counter example, expand or reduce it to have the same longitude, put the position interest in the same place as real data, and replace it with the value of actual extractor.